### PR TITLE
Fix #issue 2

### DIFF
--- a/src/prompts/scope-maker.test.ts
+++ b/src/prompts/scope-maker.test.ts
@@ -58,7 +58,20 @@ describe('scopeMaker', () => {
       const scopeConfig = scopeMaker([], { 'scope-enum': [2, 'always', ['foo', 'bar']] })[0] as ListQuestion;
 
       if (scopeConfig.choices) {
-        expect(scopeConfig.choices).toEqual(['foo', 'bar']);
+        expect(scopeConfig.choices).toEqual([
+          {
+            name: 'foo',
+            value: 'foo'
+          },
+          {
+            name: 'bar',
+            value: 'bar'
+          },
+          {
+            name: ':skip',
+            value: ''
+          }
+        ]);
       }
     });
   });

--- a/src/prompts/scope-maker.ts
+++ b/src/prompts/scope-maker.ts
@@ -1,5 +1,5 @@
 import { Rules } from '@commitlint/load';
-import { DistinctQuestion } from 'inquirer';
+import { ChoiceOptions } from 'inquirer';
 import { whenFactory } from '../when';
 import { caseValidator, emptyValidator, maxLengthValidator, minLengthValidator, validate } from '../validators';
 import { wordCaseFilter } from '../filters';
@@ -37,11 +37,11 @@ export function validatorFactory(rules: Rules) {
 }
 
 export function choicesFactory(rules: Rules) {
-  let choices: string[] | undefined;
+  let choices: ChoiceOptions[] | undefined;
   if (rules['scope-enum']) {
     const [, , scopeEnum] = rules['scope-enum'];
     if (scopeEnum && scopeEnum.length > 0) {
-      choices = scopeEnum;
+      choices = [...scopeEnum.map(scope => ({ name: scope, value: scope })), { name: ':skip', value: '' }];
     }
   }
 

--- a/src/prompts/type-maker.test.ts
+++ b/src/prompts/type-maker.test.ts
@@ -1,4 +1,6 @@
 import { Level, Rules } from '@commitlint/load';
+import { types } from 'conventional-commit-types';
+
 import { filterFactory, choicesFactory, validatorFactory, typeMaker } from './type-maker';
 
 jest.mock('conventional-commit-types');
@@ -36,10 +38,69 @@ describe('type-maker', () => {
   });
 
   describe('choicesFactory', () => {
-    describe('should return undefined if type-enum undefined', () => {
-      const result = choicesFactory({}, {});
+    describe('should return commitTypes as choices if type-enum undefined', () => {
+      const result = choicesFactory({}, types);
 
-      expect(result).toBeUndefined();
+      expect(result).toEqual([
+        {
+          name: 'feat: A new feature',
+          short: 'feat',
+          value: 'feat'
+        },
+        {
+          name: 'fix: A bug fix',
+          short: 'fix',
+          value: 'fix'
+        },
+        {
+          name: 'docs: Documentation only changes',
+          short: 'docs',
+          value: 'docs'
+        },
+        {
+          name:
+            'style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)',
+          short: 'style',
+          value: 'style'
+        },
+        {
+          name: 'refactor: A code change that neither fixes a bug nor adds a feature',
+          short: 'refactor',
+          value: 'refactor'
+        },
+        {
+          name: 'perf: A code change that improves performance',
+          short: 'perf',
+          value: 'perf'
+        },
+        {
+          name: 'test: Adding missing tests or correcting existing tests',
+          short: 'test',
+          value: 'test'
+        },
+        {
+          name:
+            'build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)',
+          short: 'build',
+          value: 'build'
+        },
+        {
+          name:
+            'ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)',
+          short: 'ci',
+          value: 'ci'
+        },
+        {
+          name: "chore: Other changes that don't modify src or test files",
+          short: 'chore',
+          value: 'chore'
+        },
+        {
+          name: 'revert: Reverts a previous commit',
+          short: 'revert',
+          value: 'revert'
+        }
+      ]);
     });
 
     describe('should return choices if type-enum exits', () => {
@@ -47,17 +108,17 @@ describe('type-maker', () => {
 
       expect(result).toEqual([
         {
-          name: 'foo ',
+          name: 'foo: ',
           short: 'foo',
           value: 'foo'
         },
         {
-          name: 'bar ',
+          name: 'bar: ',
           short: 'bar',
           value: 'bar'
         },
         {
-          name: 'baz ',
+          name: 'baz: ',
           short: 'baz',
           value: 'baz'
         }
@@ -75,17 +136,17 @@ describe('type-maker', () => {
 
         expect(result).toEqual([
           {
-            name: 'foo Fooey',
+            name: 'foo: Fooey',
             short: 'foo',
             value: 'foo'
           },
           {
-            name: 'bar Barey',
+            name: 'bar: Barey',
             short: 'bar',
             value: 'bar'
           },
           {
-            name: 'baz Bazey',
+            name: 'baz: Bazey',
             short: 'baz',
             value: 'baz'
           }
@@ -105,22 +166,22 @@ describe('type-maker', () => {
 
         expect(result).toEqual([
           {
-            name: 'foo       Fooey',
+            name: 'foo      : Fooey',
             short: 'foo',
             value: 'foo'
           },
           {
-            name: 'bar       Barey',
+            name: 'bar      : Barey',
             short: 'bar',
             value: 'bar'
           },
           {
-            name: 'baz       Bazey',
+            name: 'baz      : Bazey',
             short: 'baz',
             value: 'baz'
           },
           {
-            name: 'very-long Longey',
+            name: 'very-long: Longey',
             short: 'very-long',
             value: 'very-long'
           }

--- a/src/prompts/type-maker.ts
+++ b/src/prompts/type-maker.ts
@@ -49,13 +49,20 @@ export function choicesFactory(rules: Rules, commitTypes: CommitType) {
   if (typeEnum && typeEnum.length > 0) {
     const longest = getLongest(typeEnum);
     choices = typeEnum.map(value => ({
-      name: `${value.padEnd(longest)} ${commitTypes[value]?.description ?? ''}`,
+      name: `${value.padEnd(longest)}: ${commitTypes[value]?.description ?? ''}`,
       value: value,
       short: value
     }));
   }
 
-  return choices;
+  return (
+    choices ||
+    Object.keys(commitTypes).map(commitType => ({
+      name: `${commitType}: ${commitTypes[commitType].description ?? ''}`,
+      value: commitType,
+      short: commitType
+    }))
+  );
 }
 
 export function typeMaker(questions: Question[], rules: Rules): Question[] {


### PR DESCRIPTION
This PR is aim to fix https://github.com/martinmcwhorter/commitiquette/issues/2

according to [Inquire.js](https://github.com/SBoudrias/Inquirer.js/#list---type-list) documentation, the `choices` must be present when using `list`

So i set the default value when `type-enum` abs.

Also, i has mark scope possible to leave it blank by added `:skip` to scope choices list.