### PR TITLE
bug: fix body-maker filters ordering

### DIFF
--- a/src/prompts/body-maker.test.ts
+++ b/src/prompts/body-maker.test.ts
@@ -29,6 +29,18 @@ describe('body-maker', () => {
 
       expect(result).toBe(expected);
     });
+
+    it('should prepend body with and leading empty line', () => {
+      const rules: Rules = {
+        'body-leading-blank': [Level.Error, 'always', undefined],
+        'body-max-line-length': [Level.Error, 'never', Infinity]
+      };
+      const userTypedBody = 'my message should be prepended with an empty new line';
+
+      const result = filterFactory(rules)(userTypedBody);
+
+      expect(result).toBe('\nmy message should be prepended with an empty new line');
+    });
   });
 
   describe('transformerFactory', () => {

--- a/src/prompts/body-maker.ts
+++ b/src/prompts/body-maker.ts
@@ -26,8 +26,8 @@ export function filterFactory(rules: Rules) {
   return (value: string) =>
     pipeWith<string>(
       value,
-      v => leadingBlankFilter(v, rules['body-leading-blank']),
       v => maxLineLengthFilter(v, rules['body-max-line-length']),
+      v => leadingBlankFilter(v, rules['body-leading-blank']),
       v => v.replace(/\\n/g, '\n')
     );
 }


### PR DESCRIPTION
There's a bug in [body-maker](https://github.com/martinmcwhorter/commitiquette/blob/d48c643c863bc4d743e255f0ec07402835a32a3b/src/prompts/body-maker.ts) module which removes the _leading-empty-line_ from the commit body message when commitlint's `body-leading-blank` option is set to `always`. Previously, the [`leadingBlankFilter`](https://github.com/martinmcwhorter/commitiquette/blob/d48c643c863bc4d743e255f0ec07402835a32a3b/src/filters.ts#L5-L25) filter function works fine and [it prepends the commit body with an empty new line correctly](https://github.com/martinmcwhorter/commitiquette/blob/d48c643c863bc4d743e255f0ec07402835a32a3b/src/filters.ts#L20-L22). But, when its output - which is the empty-line-prepended commit body, gets passed into [`maxLineLengthFilter`](https://github.com/martinmcwhorter/commitiquette/blob/d48c643c863bc4d743e255f0ec07402835a32a3b/src/filters.ts#L67-L83) function, it removes the leading empty line (`\n`) that was prepended by [`leadingBlankFilter`](https://github.com/martinmcwhorter/commitiquette/blob/d48c643c863bc4d743e255f0ec07402835a32a3b/src/filters.ts#L5-L25) as it is using the [`word-wrap` package](https://www.npmjs.com/package/word-wrap). Finally, the output of this chain, does not have the leading-empty-new-line which **is required** for commitlint, and it throws an error on regarding this. Also, as leading empty new line characters does not affect maximum length of any line, there should not be any problem to apply leading empty new line _after_ splitting body message into multiple line, if necessary.
This merge request fixes this issue.